### PR TITLE
Properly handle default action.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It also supports Artifactory caching.
 
 So this program can be useful for you in any environment (CI, or personal desktop), where you have a following need:
   - retrieve assets from github project releases
-  - retrieve files from Artifactory
+  - download files from Artifactory
   - upload files to Artifactory
   - automate the process of: download a release artifact, if it exists in Artifactory, get it from there, otherwise get it directly from Github releases, along the way caching it to Artifactory for next time
 

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1,0 +1,73 @@
+/*
+Copyright © 2024 Silicon Labs
+*/
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+	"silabs/get-zap/gh"
+	"silabs/get-zap/jf"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// fetchCmd represents the fetch command
+var fetchCmd = &cobra.Command{
+	Use:   "fetch",
+	Short: "Retrieves an artifact either from Artifactory cache, or from Github, wherever it can be found.",
+	Long: `This is the default operation, if you don't pass any commands. The action performed is:
+- first the existence of release artifact is tested on Artifactory. If it's found, it's downloaded from there.
+- if it's not found on Artifactory, it's downloaded from Github. If it's found on Github, it's downloaded from there.
+- after the artifact is found on Github, it is uploaded to Artifactory, so that it can be found there next time
+	
+Note: command line arguments can modify this flow.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		Fetch(ReadGithubConfiguration(), ReadArtifactoryConfiguration(), viper.GetBool(useGh), viper.GetBool(useRt))
+	},
+}
+
+// This is what gets executed if no toplevel commands are passed.
+func Fetch(ghCfg *gh.GithubConfiguration, rtCfg *jf.ArtifactoryConfiguration, useGh bool, useRt bool) {
+	if !useGh && !useRt {
+		fmt.Println("Neither Artifactory nor Github are enabled, nothing to do.")
+		return
+	}
+
+	if !useGh {
+		// We only check artifactory, if we don't find it, we're done.
+		if ghCfg.Release == "latest" || ghCfg.Release == "all" {
+			fmt.Printf("Artifactory does not cache 'latest' or 'all' releases. When using --useGh=false, please specify a specific release.\n")
+			return
+		}
+		jf.ArtifactoryDownload(rtCfg, ghCfg.Release+"/**")
+		return
+	}
+
+	if !useRt {
+		// We only attempt to download from github, if we don't find it, we're done.
+		fmt.Printf("Downloading release '%v' of repo '%v/%v' for the platform '%v/%v'...\n", ghCfg.Release, ghCfg.Owner, ghCfg.Repo, runtime.GOOS, runtime.GOARCH)
+		gh.DownloadAssets(ghCfg, ".", true, ".zip")
+		return
+	}
+
+	// If we get here, we're going to do the following: first we attempt to download the assset from artifactory. If we can't find it, we will download it
+	// from github. If we do find it, we will then upload it to artifactory for the next time someone tries to download this same thing.
+	fmt.Printf("Full cycle not yet implemented.\n")
+
+}
+
+func init() {
+	rootCmd.AddCommand(fetchCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// fetchCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// fetchCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,10 @@ const rtUser = "rtUser"
 const rtRepo = "rtRepo"
 const rtPath = "rtPath"
 
+const useRt = "useRt"
+const useGh = "useGh"
+const localRoot = "localRoot"
+
 var cfgFile string
 
 // rootCmd represents the base command when called without any subcommands
@@ -32,7 +36,7 @@ var rootCmd = &cobra.Command{
 	Short: "Application to retrieve artifacts from github.",
 	Long:  `This application by default retrieves zap artifacts, with the right arguments, it can be used to retrieve assets from any public github repo.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		gh.DefaultAction(ReadGithubConfiguration(), ReadArtifactoryConfiguration())
+		gh.DefaultAction(ReadGithubConfiguration(), ReadArtifactoryConfiguration(), viper.GetBool(useGh), viper.GetBool(useRt))
 	},
 }
 
@@ -73,12 +77,15 @@ func init() {
 	rootCmd.PersistentFlags().String(repoArg, "zap", "Name of the github repository.")
 	rootCmd.PersistentFlags().StringP(githubTokenArg, "t", "", "Github token to use for authentication.")
 	rootCmd.PersistentFlags().StringP(releaseArg, "r", "latest", "Release to download. Specify a name, or 'all' or 'latest' for all releases.")
+	rootCmd.PersistentFlags().String(localRoot, ".", "Local root directory to download assets to. All operations are limited to within this directory.")
 	rootCmd.PersistentFlags().StringP(assetArg, "a", "local", "Asset to download. Specify a name, or 'all' or 'local' for matching the platform.")
 	rootCmd.PersistentFlags().String(rtUrl, "", "Artifactory URL.")
 	rootCmd.PersistentFlags().String(rtApiKey, "", "Artifactory API Key.")
 	rootCmd.PersistentFlags().String(rtUser, "", "Artifactory user.")
 	rootCmd.PersistentFlags().String(rtRepo, "", "Artifactory repository.")
 	rootCmd.PersistentFlags().String(rtPath, "", "Artifactory path within the repo.")
+	rootCmd.PersistentFlags().Bool(useRt, true, "Use Artifactory.")
+	rootCmd.PersistentFlags().Bool(useGh, true, "Use GitHub.")
 
 	viper.BindPFlag(ownerArg, rootCmd.PersistentFlags().Lookup(ownerArg))
 	viper.BindPFlag(repoArg, rootCmd.PersistentFlags().Lookup(repoArg))
@@ -90,6 +97,9 @@ func init() {
 	viper.BindPFlag(rtUser, rootCmd.PersistentFlags().Lookup(rtUser))
 	viper.BindPFlag(rtRepo, rootCmd.PersistentFlags().Lookup(rtRepo))
 	viper.BindPFlag(rtPath, rootCmd.PersistentFlags().Lookup(rtPath))
+	viper.BindPFlag(useRt, rootCmd.PersistentFlags().Lookup(useRt))
+	viper.BindPFlag(useGh, rootCmd.PersistentFlags().Lookup(useGh))
+	viper.BindPFlag(localRoot, rootCmd.PersistentFlags().Lookup(localRoot))
 }
 
 func initConfig() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,7 @@ var rootCmd = &cobra.Command{
 	Short: "Application to retrieve artifacts from github.",
 	Long:  `This application by default retrieves zap artifacts, with the right arguments, it can be used to retrieve assets from any public github repo.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		gh.DefaultAction(ReadGithubConfiguration(), ReadArtifactoryConfiguration(), viper.GetBool(useGh), viper.GetBool(useRt))
+		Fetch(ReadGithubConfiguration(), ReadArtifactoryConfiguration(), viper.GetBool(useGh), viper.GetBool(useRt))
 	},
 }
 

--- a/gh/general.go
+++ b/gh/general.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"runtime"
-	"silabs/get-zap/jf"
 	"strings"
 
 	"github.com/google/go-github/github"
@@ -21,36 +20,6 @@ type GithubConfiguration struct {
 	Release string
 	Token   string
 	Asset   string
-}
-
-// This is what gets executed if no toplevel commands are passed.
-func DefaultAction(ghCfg *GithubConfiguration, rtCfg *jf.ArtifactoryConfiguration, useGh bool, useRt bool) {
-	if !useGh && !useRt {
-		fmt.Println("Neither Artifactory nor Github are enabled, nothing to do.")
-		return
-	}
-
-	if !useGh {
-		// We only check artifactory, if we don't find it, we're done.
-		if ghCfg.Release == "latest" || ghCfg.Release == "all" {
-			fmt.Printf("Artifactory does not cache 'latest' or 'all' releases. When using --useGh=false, please specify a specific release.\n")
-			return
-		}
-		jf.ArtifactoryDownload(rtCfg, ghCfg.Release+"/**")
-		return
-	}
-
-	if !useRt {
-		// We only attempt to download from github, if we don't find it, we're done.
-		fmt.Printf("Downloading release '%v' of repo '%v/%v' for the platform '%v/%v'...\n", ghCfg.Release, ghCfg.Owner, ghCfg.Repo, runtime.GOOS, runtime.GOARCH)
-		DownloadAssets(ghCfg, ".", true, ".zip")
-		return
-	}
-
-	// If we get here, we're going to do the following: first we attempt to download the assset from artifactory. If we can't find it, we will download it
-	// from github. If we do find it, we will then upload it to artifactory for the next time someone tries to download this same thing.
-	fmt.Printf("Full cycle not yet implemented.\n")
-
 }
 
 func CreateGithubClient(cfg *GithubConfiguration) *github.Client {

--- a/gh/general.go
+++ b/gh/general.go
@@ -23,6 +23,36 @@ type GithubConfiguration struct {
 	Asset   string
 }
 
+// This is what gets executed if no toplevel commands are passed.
+func DefaultAction(ghCfg *GithubConfiguration, rtCfg *jf.ArtifactoryConfiguration, useGh bool, useRt bool) {
+	if !useGh && !useRt {
+		fmt.Println("Neither Artifactory nor Github are enabled, nothing to do.")
+		return
+	}
+
+	if !useGh {
+		// We only check artifactory, if we don't find it, we're done.
+		if ghCfg.Release == "latest" || ghCfg.Release == "all" {
+			fmt.Printf("Artifactory does not cache 'latest' or 'all' releases. When using --useGh=false, please specify a specific release.\n")
+			return
+		}
+		jf.ArtifactoryDownload(rtCfg, ghCfg.Release+"/**")
+		return
+	}
+
+	if !useRt {
+		// We only attempt to download from github, if we don't find it, we're done.
+		fmt.Printf("Downloading release '%v' of repo '%v/%v' for the platform '%v/%v'...\n", ghCfg.Release, ghCfg.Owner, ghCfg.Repo, runtime.GOOS, runtime.GOARCH)
+		DownloadAssets(ghCfg, ".", true, ".zip")
+		return
+	}
+
+	// If we get here, we're going to do the following: first we attempt to download the assset from artifactory. If we can't find it, we will download it
+	// from github. If we do find it, we will then upload it to artifactory for the next time someone tries to download this same thing.
+	fmt.Printf("Full cycle not yet implemented.\n")
+
+}
+
 func CreateGithubClient(cfg *GithubConfiguration) *github.Client {
 	var client *github.Client
 	if cfg.Token == "" {
@@ -36,11 +66,6 @@ func CreateGithubClient(cfg *GithubConfiguration) *github.Client {
 		client = github.NewClient(tc)
 	}
 	return client
-}
-
-func DefaultAction(ghCfg *GithubConfiguration, rtCfg *jf.ArtifactoryConfiguration) {
-	fmt.Printf("Downloading release '%v' of repo '%v/%v' for the platform '%v/%v'...\n", ghCfg.Release, ghCfg.Owner, ghCfg.Repo, runtime.GOOS, runtime.GOARCH)
-	DownloadAssets(ghCfg, ".", true, ".zip")
 }
 
 func DetermineAssetPlatform(assetName string) (os string, arch string) {

--- a/jf/artifactory.go
+++ b/jf/artifactory.go
@@ -58,7 +58,11 @@ func ArtifactoryDelete(cfg *ArtifactoryConfiguration, pattern string) {
 	fmt.Printf("Deleted files: %v\n", cnt)
 }
 
-func ArtifactoryDownload(cfg *ArtifactoryConfiguration, pattern string) {
+func ArtifactoryPattern(release string, isLocal bool) string {
+	return release + "/**"
+}
+
+func ArtifactoryDownload(cfg *ArtifactoryConfiguration, pattern string) int {
 
 	rtDetails := cfg.CreateDetails()
 
@@ -75,6 +79,7 @@ func ArtifactoryDownload(cfg *ArtifactoryConfiguration, pattern string) {
 	cobra.CheckErr(err)
 
 	fmt.Printf("Downloaded files: success %v, failure %v\n", success, failures)
+	return success
 }
 
 func ArtifactoryUpload(cfg *ArtifactoryConfiguration, pattern string) {


### PR DESCRIPTION
This PR sorts out the flow of the default action:
   - check artifactory, and if found download from there
   - check github, if found download from there
   - update the cache in artifactory, if github artifact was downloaded